### PR TITLE
Ignoring more unncessary files we need in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 **/build/
 /captures
 .externalNativeBuild
+.idea/
+app/.*
+.project
+.settings/


### PR DESCRIPTION
We have a lot of hidden folders and files that get created/generated at build time. These shouldn't be checked into the repo, otherwise we might have conflicts and random build failures.

Also testing pull request feature 💃 